### PR TITLE
Allow usage of Postgres database

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM linuxserver/baseimage
 MAINTAINER Stian Larsen <lonixx@gmail.com>
-ENV APTLIST="quassel-core libqt4-sql-sqlite sqlite"
+ENV APTLIST="quassel-core libqt4-sql-sqlite sqlite libqt4-sql-psql"
 
 
 #Applying stuff


### PR DESCRIPTION
I want to use a postgres database with my quassel-code for performance reasons.

However, after mounting my configuration quasselcore just prints `Selected storage backend is not available: "PostgreSQL"`.

Installing this dependency enables quasselcore to connect to postgres.
