### PR TITLE
Add PostgreSQL dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM linuxserver/baseimage
 MAINTAINER Stian Larsen <lonixx@gmail.com>
-ENV APTLIST="quassel-core libqt4-sql-sqlite sqlite"
+ENV APTLIST="quassel-core libqt4-sql-sqlite libqt4-sql-psql sqlite"
 
 
 #Applying stuff


### PR DESCRIPTION
It'd be great to use this with Postgres rather than SQLite. Per [the docs](http://bugs.quassel-irc.org/projects/1/wiki/PostgreSQL) (and me messing with a local copy of this repo), the way to do that is to install libqt4-sql-psql.
