### PR TITLE
Install correct dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN \
 # install packages
  apt-get update && \
  apt-get install -y \
-	libqt4-sql-psql \
-	libqt4-sql-sqlite \
+	libqt5sql5-psql \
+	libqt5sql5-sqlite \
 	quassel-core \
 	sqlite && \
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[![linuxserver.io](https://www.linuxserver.io/wp-content/uploads/2015/06/linuxserver_medium.png)](https://linuxserver.io)

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->

<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->

<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->

<!---  -->

Quassel is compiled against Qt5 in xenial which means it needs qt5-libraries:

```
root@7362cf033a53:/config# ldd `which quasselcore`
        linux-vdso.so.1 =>  (0x00007fff683f7000)
        libQt5Network.so.5 => /usr/lib/x86_64-linux-gnu/libQt5Network.so.5 (0x00007fce1fac5000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fce1f8c1000)
        libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007fce1f6a6000)
        libQt5Script.so.5 => /usr/lib/x86_64-linux-gnu/libQt5Script.so.5 (0x00007fce1f41e000)
        libQt5Sql.so.5 => /usr/lib/x86_64-linux-gnu/libQt5Sql.so.5 (0x00007fce1f3dc000)
        libqca-qt5.so.2 => /usr/lib/x86_64-linux-gnu/libqca-qt5.so.2 (0x00007fce1f0c9000)
        libQt5Core.so.5 => /usr/lib/x86_64-linux-gnu/libQt5Core.so.5 (0x00007fce1ebf3000)
        libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007fce1e871000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fce1e4a7000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fce1e28a000)
        libproxy.so.1 => /usr/lib/x86_64-linux-gnu/libproxy.so.1 (0x00007fce1e069000)
        /lib64/ld-linux-x86-64.so.2 (0x0000556b6c6bb000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fce1dd5f000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fce1db49000)
        libicui18n.so.55 => /usr/lib/x86_64-linux-gnu/libicui18n.so.55 (0x00007fce1d6e7000)
        libicuuc.so.55 => /usr/lib/x86_64-linux-gnu/libicuuc.so.55 (0x00007fce1d352000)
        libpcre16.so.3 => /usr/lib/x86_64-linux-gnu/libpcre16.so.3 (0x00007fce1d0ec000)
        libglib-2.0.so.0 => /lib/x86_64-linux-gnu/libglib-2.0.so.0 (0x00007fce1cddb000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007fce1cbd2000)
        libicudata.so.55 => /usr/lib/x86_64-linux-gnu/libicudata.so.55 (0x00007fce1b11b000)
        libpcre.so.3 => /lib/x86_64-linux-gnu/libpcre.so.3 (0x00007fce1aeaa000)
```

.
