### PR TITLE
Rebasing to Alpine 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsiobase/alpine:3.9 as build-stage
+FROM lsiobase/alpine:3.10 as build-stage
 
 # build time arguements
 ARG CXXFLAGS="\
@@ -59,7 +59,7 @@ RUN \
  make DESTDIR=/build/quassel install && \
  paxmark -m /build/quassel/usr/bin/quasselcore
 
-FROM lsiobase/alpine:3.9
+FROM lsiobase/alpine:3.10
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM lsiobase/alpine:arm64v8-3.9 as build-stage
+FROM lsiobase/alpine:arm64v8-3.10 as build-stage
 
 # build time arguements
 ARG CXXFLAGS="\
@@ -58,7 +58,7 @@ RUN \
  make -j2 && \
  make DESTDIR=/build/quassel install
 
-FROM lsiobase/alpine:arm64v8-3.9
+FROM lsiobase/alpine:arm64v8-3.10
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM lsiobase/alpine:arm32v7-3.9 as build-stage
+FROM lsiobase/alpine:arm32v7-3.10 as build-stage
 
 # build time arguements
 ARG CXXFLAGS="\
@@ -59,7 +59,7 @@ RUN \
  make DESTDIR=/build/quassel install && \
  paxmark -m /build/quassel/usr/bin/quasselcore
 
-FROM lsiobase/alpine:arm32v7-3.9
+FROM lsiobase/alpine:arm32v7-3.10
 
 # set version label
 ARG BUILD_DATE

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -111,6 +111,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "28.06.19:", desc: "Rebasing to alpine 3.10." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }
   - { date: "20.03.19:", desc: "Make stateless operation an option, with input from one of the quassel team." }
   - { date: "26.01.19:", desc: "Add pipeline logic and multi arch." }


### PR DESCRIPTION
This is part of a mass upgrade to 3.10. 

Basic smoke test should be performed before merging and notes should be tracked in the internal 3.10 Spreadsheet.