### PR TITLE
Add missing dependency for blowfish encryption support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ RUN \
 	qt5-qtbase-dev \
 	qt5-qtscript-dev \
 	qt5-qtbase-postgresql \
-	qt5-qtbase-sqlite
+	qt5-qtbase-sqlite \
+	qca-dev
 
 # fetch source
 RUN \
@@ -79,7 +80,8 @@ RUN \
 	qt5-qtbase \
 	qt5-qtbase-postgresql \
 	qt5-qtbase-sqlite \
-	qt5-qtscript
+	qt5-qtscript \
+	libqca
 
 # copy artifacts build stage
 COPY --from=build-stage /build/quassel/usr/bin/ /usr/bin/

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -26,7 +26,8 @@ RUN \
 	qt5-qtbase-dev \
 	qt5-qtscript-dev \
 	qt5-qtbase-postgresql \
-	qt5-qtbase-sqlite
+	qt5-qtbase-sqlite \
+	qca-dev
 
 # fetch source
 RUN \
@@ -78,7 +79,8 @@ RUN \
 	qt5-qtbase \
 	qt5-qtbase-postgresql \
 	qt5-qtbase-sqlite \
-	qt5-qtscript
+	qt5-qtscript \
+	libqca
 
 # copy artifacts build stage
 COPY --from=build-stage /build/quassel/usr/bin/ /usr/bin/

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -26,7 +26,8 @@ RUN \
 	qt5-qtbase-dev \
 	qt5-qtscript-dev \
 	qt5-qtbase-postgresql \
-	qt5-qtbase-sqlite
+	qt5-qtbase-sqlite \
+	qca-dev
 
 # fetch source
 RUN \
@@ -79,7 +80,8 @@ RUN \
 	qt5-qtbase \
 	qt5-qtbase-postgresql \
 	qt5-qtbase-sqlite \
-	qt5-qtscript
+	qt5-qtscript \
+	libqca
 
 # copy artifacts build stage
 COPY --from=build-stage /build/quassel/usr/bin/ /usr/bin/


### PR DESCRIPTION
Once qca-dev is installed, blowfish support will automatically be
enabled by cmake.

Fixes #38